### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Frontier's website. Linking is only required if you purchased the game via Steam
           
        `alacritty -e ./MinEdLauncher %command% /autorun /autoquit`  
        `gnome-terminal -- ./MinEdLauncher %command% /autorun /autoquit`  
-       `konsole -e ./MinEdLauncher %command% /autorun /autoquit`
+       `LD_LIBRARY_PATH="" konsole -e env LD_LIBRARY_PATH="$LD_LIBRARY_PATH" ./MinEdLauncher %command% /autorun /autoquit`
    
        **Steam Deck users** - See [wiki](https://github.com/rfvgyhn/min-ed-launcher/wiki/Steam-Deck-Usage) for special instructions
 5. Launch your game as you normally would in Steam


### PR DESCRIPTION
Konsole no longer launches when started from the steam runtime environment. Unsetting LD_LIBRARY_PATH allows Konsole to launch but also causes Proton to run using system libraries causing undefined behavior. Resetting LD_LIBRARY_PATH inside the Konsole window solves this.