### PR TITLE
feat: per-process launch delay with configurable reference points

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,15 +227,28 @@ Linux: `$XDG_CONFIG_HOME/min-ed-launcher/settings.json` (`~/.config` if `$XDG_CO
 | `cacheDir`                | string | *(OS default)*               | Directory for update downloads. See [cache] section for default location        |
 | `gameStartDelay`          | int    | `0`                          | Seconds to wait after starting processes but before launching the game          |
 | `shutdownDelay`           | int    | `0`                          | Seconds to wait before closing processes                                        |
+| `journalDir`              | string | *(auto-detected)*            | Path to the Elite Dangerous journal directory (only needed when auto-detection fails) |
 
 #### Process fields
 
-| Field               | Type   | Default      | Description                                              |
-|---------------------|--------|--------------|----------------------------------------------------------|
-| `fileName`          | string | *(required)* | Path to executable                                       |
-| `arguments`         | string | *null*       | Command-line arguments                                   |
-| `restartOnRelaunch` | bool   | `false`      | Restart the process when the game restarts via `/restart` |
-| `keepOpen`          | bool   | `false`      | Don't stop this process when the launcher exits          |
+| Field               | Type   | Default         | Description                                                                           |
+|---------------------|--------|-----------------|---------------------------------------------------------------------------------------|
+| `fileName`          | string | *(required)*    | Path to executable                                                                    |
+| `arguments`         | string | *null*          | Command-line arguments                                                                |
+| `restartOnRelaunch` | bool   | `false`         | Restart the process when the game restarts via `/restart`                             |
+| `keepOpen`          | bool   | `false`         | Don't stop this process when the launcher exits                                       |
+| `delay`             | int    | `0`             | Seconds to delay before launching this process. See [delay reference](#delay-reference) below |
+| `delayReference`    | string | `"processStart"` | When the delay is measured from. See [delay reference](#delay-reference) below        |
+
+##### Delay reference
+
+`delayReference` controls what event `delay` is measured from:
+
+- `processStart` (default) — delay is measured from when min-ed-launcher starts the pre-game processes. Equivalent to the previous behaviour with no delay settings.
+- `gameLaunch` — delay is measured from when the game binary is launched. Supports negative values, in which case the process starts `|delay|` seconds **before** the game (min-ed-launcher will wait that long before launching the game).
+- `journalActive` — process starts when Elite Dangerous begins writing to its journal log (i.e. once you're actually past the main menu). An optional `delay` can be added on top. Falls back to starting immediately if the journal directory can't be found. Times out after five minutes of waiting.
+
+Processes with `restartOnRelaunch: true` re-fire against the new game launch / journal activity on each `/restart` cycle.
 
 > [!NOTE]
 > When specifying a path for `gameLocation`, `cacheDir` or `processes.fileName` on Windows, it's required to escape backslashes. Make sure to use a

--- a/src/MinEdLauncher/App.fs
+++ b/src/MinEdLauncher/App.fs
@@ -12,6 +12,26 @@ open System.Threading.Tasks
 open MinEdLauncher.Types
 open FsToolkit.ErrorHandling
 
+let private findJournalDir () =
+    let home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
+    let candidates =
+        if RuntimeInformation.IsOSPlatform(OSPlatform.Windows) then
+            [ Path.Combine(home, "Saved Games", "Frontier Developments", "Elite Dangerous") ]
+        else
+            [ Path.Combine(home, ".local", "share", "Frontier Developments", "Elite Dangerous")
+              Path.Combine(home, ".steam", "steam", "steamapps", "compatdata", "359320", "pfx", "drive_c", "users", "steamuser", "Saved Games", "Frontier Developments", "Elite Dangerous")
+              Path.Combine(home, ".local", "share", "Steam", "steamapps", "compatdata", "359320", "pfx", "drive_c", "users", "steamuser", "Saved Games", "Frontier Developments", "Elite Dangerous") ]
+    candidates |> List.tryFind Directory.Exists
+
+let private createJournalSignal (dirPath: string) =
+    let tcs = TaskCompletionSource<unit>()
+    let watcher = new FileSystemWatcher(dirPath, "Journal.*.log")
+    watcher.NotifyFilter <- NotifyFilters.LastWrite ||| NotifyFilters.FileName
+    watcher.Created.Add(fun _ -> tcs.TrySetResult() |> ignore)
+    watcher.Changed.Add(fun _ -> tcs.TrySetResult() |> ignore)
+    watcher.EnableRaisingEvents <- true
+    tcs.Task, (watcher :> IDisposable)
+
 type LoginError =
 | ActionRequired of string
 | CouldntConfirmOwnership of Platform
@@ -295,8 +315,8 @@ let private renewEpicTokenIfNeeded platform token =
     | _ -> Ok () |> Task.fromResult
     |> TaskResult.mapError InvalidSession
 
-let rec private launchLoop initialLaunch settings playableProducts (session: EdSession) persistentRunning relaunchRunning cancellationToken processArgs = taskResult {      
-    let! selectedProduct = 
+let rec private launchLoop initialLaunch settings playableProducts (session: EdSession) persistentRunning relaunchRunning (journalSignal: Task<unit> option) cancellationToken processArgs = taskResult {
+    let! selectedProduct =
         if settings.AutoRun && initialLaunch then
             playableProducts
             |> Product.selectProduct settings.ProductWhitelist
@@ -306,49 +326,125 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
         else None
         |> Result.requireSome NoSelectedProduct
     let didLoop = not initialLaunch
-    
+
     match selectedProduct with
     | Console.ProductSelection.Exit ->
         return (persistentRunning |> Option.defaultValue []) @ (relaunchRunning |> Option.defaultValue []), didLoop
     | Console.ProductSelection.Product selectedProduct ->
         let! p = Product.validateForRun settings.CbLauncherDir settings.WatchForCrashes selectedProduct |> Result.mapError InvalidProductState
         let pArgs() = processArgs selectedProduct
-        let logStart (ps: LauncherProcess list) = ps |> List.iter (fun p -> Log.info $"Starting process %s{p.Name}")        
-        let persistentStartInfos, relaunchStartInfos =
-            let relaunchProcesses = settings.Processes |> List.filter _.RestartOnRelaunch |> List.map _.Info
+        let logStart (ps: LauncherProcess list) = ps |> List.iter (fun p -> Log.info $"Starting process %s{p.Name}")
+
+        let byReference ref (procs: {| Info: LauncherProcess; RestartOnRelaunch: bool; KeepOpen: bool; Delay: ProcessDelay |} list) = procs |> List.filter (fun proc -> proc.Delay.Reference = ref)
+        let processStartProcs, gameLaunchProcs, gameRunningProcs =
             match persistentRunning with
             | Some _ ->
-                relaunchProcesses |> logStart
-                [], relaunchProcesses
+                let relaunchProcs = settings.Processes |> List.filter _.RestartOnRelaunch
+                relaunchProcs |> List.map _.Info |> logStart
+                relaunchProcs |> byReference ProcessStart,
+                relaunchProcs |> byReference GameLaunch,
+                relaunchProcs |> byReference GameRunning
             | None ->
                 settings.Processes |> List.map _.Info |> logStart
-                
                 if settings.DryRun then
-                    [], []
+                    [], [], []
                 else
-                    settings.Processes |> List.filter (fun p -> not p.RestartOnRelaunch) |> List.map _.Info, relaunchProcesses
-        
+                    settings.Processes |> byReference ProcessStart,
+                    settings.Processes |> byReference GameLaunch,
+                    settings.Processes |> byReference GameRunning
+
+        let persistentStartInfos, relaunchStartInfos =
+            let relaunchProcesses = processStartProcs |> List.filter _.RestartOnRelaunch |> List.map _.Info
+            match persistentRunning with
+            | Some _ -> [], relaunchProcesses
+            | None ->
+                processStartProcs |> List.filter (fun p -> not p.RestartOnRelaunch) |> List.map _.Info, relaunchProcesses
+
         if not initialLaunch then
             do! renewEpicTokenIfNeeded settings.Platform session.PlatformToken
-        
-        let persistentProcesses = persistentRunning |> Option.defaultWith (fun () -> Process.launchProcesses false persistentStartInfos)
+
+        let immediateStartInfos, delayedProcessStart =
+            match persistentRunning with
+            | Some _ -> persistentStartInfos, []
+            | None ->
+                let immediate = processStartProcs |> List.filter (fun p -> p.Delay.Seconds = 0 && not p.RestartOnRelaunch) |> List.map _.Info
+                let delayed = processStartProcs |> List.filter (fun p -> p.Delay.Seconds > 0 && not p.RestartOnRelaunch)
+                immediate, delayed
+
+        let persistentProcesses = persistentRunning |> Option.defaultWith (fun () -> Process.launchProcesses false immediateStartInfos)
         let mutable relaunchProcesses = Process.launchProcesses false relaunchStartInfos
-        
+
+        let delayedTasks = ResizeArray<Task<(Process * LauncherProcess) list>>()
+
+        for proc in delayedProcessStart do
+            let delay = TimeSpan.FromSeconds(float proc.Delay.Seconds)
+            Log.info $"Process %s{proc.Info.Name} will start after %.0f{delay.TotalSeconds}s"
+            delayedTasks.Add(Process.launchProcessesDelayed delay [proc.Info])
+
+        let gameLaunchSignal = TaskCompletionSource<unit>()
+
+        for proc in gameLaunchProcs do
+            let delaySec = proc.Delay.Seconds
+            let t = task {
+                if delaySec < 0 then
+                    ()
+                else
+                    do! gameLaunchSignal.Task
+                    if delaySec > 0 then
+                        Log.info $"Process %s{proc.Info.Name} will start %d{delaySec}s after game launch"
+                        do! Task.Delay(TimeSpan.FromSeconds(float delaySec))
+                return Process.launchProcesses false [proc.Info]
+            }
+            delayedTasks.Add(t)
+
+        let preGameTasks =
+            gameLaunchProcs
+            |> List.filter (fun p -> p.Delay.Seconds < 0)
+            |> List.map (fun proc ->
+                let delaySec = abs proc.Delay.Seconds
+                Log.info $"Process %s{proc.Info.Name} will start %d{delaySec}s before game launch"
+                Process.launchProcessesDelayed TimeSpan.Zero [proc.Info], delaySec)
+
+        match journalSignal with
+        | Some signal ->
+            for proc in gameRunningProcs do
+                let delaySec = proc.Delay.Seconds
+                let t = task {
+                    do! signal
+                    if delaySec > 0 then
+                        Log.info $"Process %s{proc.Info.Name} will start %d{delaySec}s after journal change"
+                        do! Task.Delay(TimeSpan.FromSeconds(float delaySec))
+                    else
+                        Log.info $"Process %s{proc.Info.Name} starting on journal change"
+                    return Process.launchProcesses false [proc.Info]
+                }
+                delayedTasks.Add(t)
+        | None ->
+            if not gameRunningProcs.IsEmpty then
+                Log.warn "Journal directory not found; journalChange-delayed processes will start immediately"
+                for proc in gameRunningProcs do
+                    delayedTasks.Add(Process.launchProcessesDelayed (TimeSpan.FromSeconds(float proc.Delay.Seconds |> max 0.)) [proc.Info])
+
         if initialLaunch && settings.GameStartDelay > TimeSpan.Zero then
             Log.info $"Delaying game launch for %.2f{settings.GameStartDelay.TotalSeconds} seconds"
             do! Task.Delay settings.GameStartDelay
-        
+
+        let maxPreGameDelay = preGameTasks |> List.map snd |> List.fold max 0
+        if maxPreGameDelay > 0 then
+            Log.info $"Waiting %d{maxPreGameDelay}s for pre-game processes"
+            do! Task.Delay(TimeSpan.FromSeconds(float maxPreGameDelay))
+
         let waitForEdExit =
             settings.QuitMode = WaitForExit
             || settings.QuitMode = WaitForInput
             || settings.Restart.IsSome
             || not settings.Processes.IsEmpty
             || not settings.ShutdownProcesses.IsEmpty
-        
+
+        gameLaunchSignal.TrySetResult() |> ignore
         launchProduct settings.DryRun settings.CompatTool pArgs selectedProduct.Name waitForEdExit p
-        
+
         if not waitForEdExit then
-            // Wait for ED Process to start before exiting
             let maxTries = 30
             let mutable tries = 0
             while tries < maxTries do
@@ -362,17 +458,33 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
             let timeout = settings.Restart |> Option.defaultValue 3000L
             while settings.Restart.IsSome && not (Console.cancelRestart timeout) do
                 Process.stopProcesses settings.ShutdownTimeout relaunchProcesses
-                logStart relaunchStartInfos
-                relaunchProcesses <- Process.launchProcesses false relaunchStartInfos
-                
+                let relaunchInfos = processStartProcs |> List.filter _.RestartOnRelaunch |> List.map _.Info
+                relaunchInfos |> logStart
+                relaunchProcesses <- Process.launchProcesses false relaunchInfos
+
                 do! renewEpicTokenIfNeeded settings.Platform session.PlatformToken
-                
+
                 launchProduct settings.DryRun settings.CompatTool pArgs selectedProduct.Name true p
-            
+
+            let! delayedProcesses =
+                if delayedTasks.Count > 0 then
+                    task {
+                        let! results = Task.WhenAll(delayedTasks)
+                        return results |> Array.toList |> List.concat
+                    }
+                else
+                    task { return [] }
+
+            let preGameProcesses =
+                preGameTasks
+                |> List.collect (fun (t, _) -> if t.IsCompleted then t.Result else [])
+
+            let allProcesses = persistentProcesses @ relaunchProcesses @ delayedProcesses @ preGameProcesses
+
             if settings.QuitMode = WaitForInput then
-                return! launchLoop false settings playableProducts session (Some persistentProcesses) (Some relaunchProcesses) cancellationToken processArgs
+                return! launchLoop false settings playableProducts session (Some allProcesses) (Some relaunchProcesses) journalSignal cancellationToken processArgs
             else
-                return persistentProcesses @ relaunchProcesses, didLoop
+                return allProcesses, didLoop
 }
 
 let run settings launcherVersion cancellationToken = taskResult {
@@ -572,7 +684,20 @@ let run settings launcherVersion cancellationToken = taskResult {
     let gameLanguage = Cobra.getGameLang settings.CbLauncherDir settings.PreferredLanguage
     let processArgs = Product.createArgString settings.DisplayMode gameLanguage connection.Session machineId (getRunningTime()) settings.WatchForCrashes settings.Platform SHA1.hashFile
     
-    let! runningProcesses, didLoop = launchLoop true settings playableProducts connection.Session None None cancellationToken processArgs
+    let journalDir = findJournalDir()
+    let journalSignal, journalWatcher =
+        match journalDir with
+        | Some dir ->
+            Log.debug $"Watching journal directory: %s{dir}"
+            let signal, watcher = createJournalSignal dir
+            Some signal, Some watcher
+        | None ->
+            Log.debug "Journal directory not found"
+            None, None
+
+    let! runningProcesses, didLoop = launchLoop true settings playableProducts connection.Session None None journalSignal cancellationToken processArgs
+
+    journalWatcher |> Option.iter _.Dispose()
     
     if settings.ShutdownDelay > TimeSpan.Zero then
         Log.info $"Delaying shutdown for %.2f{settings.ShutdownDelay.TotalSeconds} seconds"

--- a/src/MinEdLauncher/App.fs
+++ b/src/MinEdLauncher/App.fs
@@ -322,7 +322,7 @@ let private renewEpicTokenIfNeeded platform token =
     | _ -> Ok () |> Task.fromResult
     |> TaskResult.mapError InvalidSession
 
-let rec private launchLoop initialLaunch settings playableProducts (session: EdSession) persistentRunning relaunchRunning (journalSignal: Task<bool> option) (journalCts: CancellationTokenSource option) cancellationToken processArgs = taskResult {
+let rec private launchLoop initialLaunch settings playableProducts (session: EdSession) persistentRunning relaunchRunning (journalDir: string option) cancellationToken processArgs = taskResult {
     let! selectedProduct =
         if settings.AutoRun && initialLaunch then
             playableProducts
@@ -343,22 +343,16 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
         let logStart (ps: LauncherProcess list) = ps |> List.iter (fun p -> Log.info $"Starting process %s{p.Name}")
 
         let byReference ref (procs: {| Info: LauncherProcess; RestartOnRelaunch: bool; KeepOpen: bool; Delay: ProcessDelay |} list) = procs |> List.filter (fun proc -> proc.Delay.Reference = ref)
-        let processStartProcs, gameLaunchProcs, gameRunningProcs =
+        let processStartProcs =
             match persistentRunning with
             | Some _ ->
                 let relaunchProcs = settings.Processes |> List.filter _.RestartOnRelaunch
                 relaunchProcs |> List.map _.Info |> logStart
-                relaunchProcs |> byReference ProcessStart,
-                relaunchProcs |> byReference GameLaunch,
-                relaunchProcs |> byReference GameRunning
+                relaunchProcs |> byReference ProcessStart
             | None ->
                 settings.Processes |> List.map _.Info |> logStart
-                if settings.DryRun then
-                    [], [], []
-                else
-                    settings.Processes |> byReference ProcessStart,
-                    settings.Processes |> byReference GameLaunch,
-                    settings.Processes |> byReference GameRunning
+                if settings.DryRun then []
+                else settings.Processes |> byReference ProcessStart
 
         let persistentStartInfos, relaunchStartInfos =
             let relaunchProcesses = processStartProcs |> List.filter _.RestartOnRelaunch |> List.map _.Info
@@ -382,74 +376,101 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
         let mutable relaunchProcesses = Process.launchProcesses false relaunchStartInfos
 
         let delayedTasks = ResizeArray<Task<(Process * LauncherProcess) list>>()
+        let preGameTasksAccum = ResizeArray<Task<(Process * LauncherProcess) list> * TimeSpan>()
+        let journalCtsAccum = ResizeArray<CancellationTokenSource>()
+        let journalWatcherAccum = ResizeArray<IDisposable>()
+
+        let journalTimeout = TimeSpan.FromMinutes(5.)
+
+        // Schedule game-launch/journal-active processes for one launch iteration.
+        // Returns the TCS that callers must complete once the game has been launched
+        // and the max pre-game delay for this iteration.
+        let scheduleGameLaunchAndJournal (procs: {| Info: LauncherProcess; RestartOnRelaunch: bool; KeepOpen: bool; Delay: ProcessDelay |} list) =
+            let gameLaunchSignal = TaskCompletionSource<unit>()
+            let gameLaunchProcs = procs |> byReference GameLaunch
+            let journalActiveProcs = procs |> byReference JournalActive
+
+            // Non-negative game-launch delays run on or after the launch signal.
+            // Negative delays are handled via preGameTasks so they don't launch twice.
+            for proc in gameLaunchProcs |> List.filter (fun p -> p.Delay.Amount >= TimeSpan.Zero) do
+                let delay = proc.Delay.Amount
+                let t = task {
+                    do! gameLaunchSignal.Task
+                    if delay > TimeSpan.Zero then
+                        Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after game launch"
+                        do! Task.Delay(delay)
+                    return Process.launchProcesses false [proc.Info]
+                }
+                delayedTasks.Add(t)
+
+            let preGame =
+                gameLaunchProcs
+                |> List.filter (fun p -> p.Delay.Amount < TimeSpan.Zero)
+                |> List.map (fun proc ->
+                    let delay = proc.Delay.Amount.Negate()
+                    Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s before game launch"
+                    Process.launchProcessesDelayed TimeSpan.Zero [proc.Info], delay)
+            for item in preGame do preGameTasksAccum.Add(item)
+            let maxPreGameDelay = preGame |> List.map snd |> List.fold max TimeSpan.Zero
+
+            match journalDir with
+            | Some dir when not (List.isEmpty journalActiveProcs) ->
+                Log.debug $"Watching journal directory: %s{dir}"
+                let localCts = new CancellationTokenSource()
+                let signal, watcher = createJournalSignal dir localCts
+                journalCtsAccum.Add(localCts)
+                journalWatcherAccum.Add(watcher)
+                for proc in journalActiveProcs do
+                    let delay = proc.Delay.Amount
+                    let t = task {
+                        let timeoutTask = Task.Delay(journalTimeout)
+                        let! completed = Task.WhenAny(signal, timeoutTask)
+                        if completed = timeoutTask then
+                            Log.warn $"Process %s{proc.Info.Name} not started (timed out waiting for journal activity)"
+                            return []
+                        else
+                            let! signaled = signal
+                            if signaled then
+                                if delay > TimeSpan.Zero then
+                                    Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after journal activity"
+                                    do! Task.Delay(delay)
+                                else
+                                    Log.info $"Process %s{proc.Info.Name} starting on journal activity"
+                                return Process.launchProcesses false [proc.Info]
+                            else
+                                Log.warn $"Process %s{proc.Info.Name} not started (game exited before journal activity detected)"
+                                return []
+                    }
+                    delayedTasks.Add(t)
+            | _ ->
+                if not journalActiveProcs.IsEmpty then
+                    if journalDir.IsNone then
+                        Log.warn "Journal directory not found; journalActive-delayed processes will start immediately"
+                    for proc in journalActiveProcs do
+                        let delay = if proc.Delay.Amount > TimeSpan.Zero then proc.Delay.Amount else TimeSpan.Zero
+                        delayedTasks.Add(Process.launchProcessesDelayed delay [proc.Info])
+
+            gameLaunchSignal, maxPreGameDelay
+
+        let initialProcs =
+            match persistentRunning, settings.DryRun with
+            | Some _, _ -> settings.Processes |> List.filter _.RestartOnRelaunch
+            | None, true -> []
+            | None, false -> settings.Processes
+        let initialSignal, initialPreGameDelay = scheduleGameLaunchAndJournal initialProcs
+        let mutable gameLaunchSignal = initialSignal
 
         for proc in delayedProcessStart do
             Log.info $"Process %s{proc.Info.Name} will start after %.0f{proc.Delay.Amount.TotalSeconds}s"
             delayedTasks.Add(Process.launchProcessesDelayed proc.Delay.Amount [proc.Info])
 
-        let gameLaunchSignal = TaskCompletionSource<unit>()
-
-        // Processes with non-negative game-launch delays start on or after the game-launch signal.
-        // Negative delays are handled separately via preGameTasks so we don't launch them twice.
-        for proc in gameLaunchProcs |> List.filter (fun p -> p.Delay.Amount >= TimeSpan.Zero) do
-            let delay = proc.Delay.Amount
-            let t = task {
-                do! gameLaunchSignal.Task
-                if delay > TimeSpan.Zero then
-                    Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after game launch"
-                    do! Task.Delay(delay)
-                return Process.launchProcesses false [proc.Info]
-            }
-            delayedTasks.Add(t)
-
-        let preGameTasks =
-            gameLaunchProcs
-            |> List.filter (fun p -> p.Delay.Amount < TimeSpan.Zero)
-            |> List.map (fun proc ->
-                let delay = proc.Delay.Amount.Negate()
-                Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s before game launch"
-                Process.launchProcessesDelayed TimeSpan.Zero [proc.Info], delay)
-
-        let journalTimeout = TimeSpan.FromMinutes(5.)
-        match journalSignal with
-        | Some signal ->
-            for proc in gameRunningProcs do
-                let delay = proc.Delay.Amount
-                let t = task {
-                    let timeoutTask = Task.Delay(journalTimeout)
-                    let! completed = Task.WhenAny(signal, timeoutTask)
-                    if completed = timeoutTask then
-                        Log.warn $"Process %s{proc.Info.Name} not started (timed out waiting for journal activity)"
-                        return []
-                    else
-                        let! signaled = signal
-                        if signaled then
-                            if delay > TimeSpan.Zero then
-                                Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after journal activity"
-                                do! Task.Delay(delay)
-                            else
-                                Log.info $"Process %s{proc.Info.Name} starting on journal activity"
-                            return Process.launchProcesses false [proc.Info]
-                        else
-                            Log.warn $"Process %s{proc.Info.Name} not started (game exited before journal activity detected)"
-                            return []
-                }
-                delayedTasks.Add(t)
-        | None ->
-            if not gameRunningProcs.IsEmpty then
-                Log.warn "Journal directory not found; gameRunning-delayed processes will start immediately"
-                for proc in gameRunningProcs do
-                    let delay = if proc.Delay.Amount > TimeSpan.Zero then proc.Delay.Amount else TimeSpan.Zero
-                    delayedTasks.Add(Process.launchProcessesDelayed delay [proc.Info])
-
         if initialLaunch && settings.GameStartDelay > TimeSpan.Zero then
             Log.info $"Delaying game launch for %.2f{settings.GameStartDelay.TotalSeconds} seconds"
             do! Task.Delay settings.GameStartDelay
 
-        let maxPreGameDelay = preGameTasks |> List.map snd |> List.fold max TimeSpan.Zero
-        if maxPreGameDelay > TimeSpan.Zero then
-            Log.info $"Waiting %.0f{maxPreGameDelay.TotalSeconds}s for pre-game processes"
-            do! Task.Delay(maxPreGameDelay)
+        if initialPreGameDelay > TimeSpan.Zero then
+            Log.info $"Waiting %.0f{initialPreGameDelay.TotalSeconds}s for pre-game processes"
+            do! Task.Delay(initialPreGameDelay)
 
         let waitForEdExit =
             settings.QuitMode = WaitForExit
@@ -476,16 +497,27 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
             let timeout = settings.Restart |> Option.defaultValue 3000L
             while settings.Restart.IsSome && not (Console.cancelRestart timeout) do
                 Process.stopProcesses settings.ShutdownTimeout relaunchProcesses
-                let relaunchInfos = processStartProcs |> List.filter _.RestartOnRelaunch |> List.map _.Info
+                let restartProcs = settings.Processes |> List.filter _.RestartOnRelaunch
+                let relaunchInfos = restartProcs |> byReference ProcessStart |> List.map _.Info
                 relaunchInfos |> logStart
                 relaunchProcesses <- Process.launchProcesses false relaunchInfos
 
+                // Re-schedule gameLaunch + journalActive restart-on-relaunch procs so they
+                // fire against the new game launch / new journal activity.
+                let nextSignal, nextPreGameDelay = scheduleGameLaunchAndJournal restartProcs
+
                 do! renewEpicTokenIfNeeded settings.Platform session.PlatformToken
+
+                if nextPreGameDelay > TimeSpan.Zero then
+                    do! Task.Delay(nextPreGameDelay)
+
+                nextSignal.TrySetResult() |> ignore
+                gameLaunchSignal <- nextSignal
 
                 launchProduct settings.DryRun settings.CompatTool pArgs selectedProduct.Name true p
 
-            // Cancel journal signal since game has exited
-            journalCts |> Option.iter _.Cancel()
+            // Cancel any in-flight journal watchers; the game has exited.
+            for cts in journalCtsAccum do cts.Cancel()
 
             let! delayedProcesses =
                 if delayedTasks.Count > 0 then
@@ -497,13 +529,17 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
                     task { return [] }
 
             let preGameProcesses =
-                preGameTasks
+                preGameTasksAccum
+                |> Seq.toList
                 |> List.collect (fun (t, _) -> if t.IsCompleted then t.Result else [])
+
+            for watcher in journalWatcherAccum do watcher.Dispose()
+            for cts in journalCtsAccum do cts.Dispose()
 
             let allProcesses = persistentProcesses @ relaunchProcesses @ delayedProcesses @ preGameProcesses
 
             if settings.QuitMode = WaitForInput then
-                return! launchLoop false settings playableProducts session (Some allProcesses) (Some relaunchProcesses) journalSignal journalCts cancellationToken processArgs
+                return! launchLoop false settings playableProducts session (Some allProcesses) (Some relaunchProcesses) journalDir cancellationToken processArgs
             else
                 return allProcesses, didLoop
 }
@@ -706,21 +742,11 @@ let run settings launcherVersion cancellationToken = taskResult {
     let processArgs = Product.createArgString settings.DisplayMode gameLanguage connection.Session machineId (getRunningTime()) settings.WatchForCrashes settings.Platform SHA1.hashFile
     
     let journalDir = findJournalDir settings.JournalDir
-    let journalCts = new CancellationTokenSource()
-    let journalSignal, journalWatcher =
-        match journalDir with
-        | Some dir ->
-            Log.debug $"Watching journal directory: %s{dir}"
-            let signal, watcher = createJournalSignal dir journalCts
-            Some signal, Some watcher
-        | None ->
-            Log.debug "Journal directory not found"
-            None, None
+    match journalDir with
+    | Some dir -> Log.debug $"Watching journal directory: %s{dir}"
+    | None -> Log.debug "Journal directory not found"
 
-    let! runningProcesses, didLoop = launchLoop true settings playableProducts connection.Session None None journalSignal (Some journalCts) cancellationToken processArgs
-
-    journalWatcher |> Option.iter _.Dispose()
-    journalCts.Dispose()
+    let! runningProcesses, didLoop = launchLoop true settings playableProducts connection.Session None None journalDir cancellationToken processArgs
     
     if settings.ShutdownDelay > TimeSpan.Zero then
         Log.info $"Delaying shutdown for %.2f{settings.ShutdownDelay.TotalSeconds} seconds"

--- a/src/MinEdLauncher/App.fs
+++ b/src/MinEdLauncher/App.fs
@@ -389,16 +389,15 @@ let rec private launchLoop initialLaunch settings playableProducts (session: EdS
 
         let gameLaunchSignal = TaskCompletionSource<unit>()
 
-        for proc in gameLaunchProcs do
+        // Processes with non-negative game-launch delays start on or after the game-launch signal.
+        // Negative delays are handled separately via preGameTasks so we don't launch them twice.
+        for proc in gameLaunchProcs |> List.filter (fun p -> p.Delay.Amount >= TimeSpan.Zero) do
             let delay = proc.Delay.Amount
             let t = task {
-                if delay < TimeSpan.Zero then
-                    ()
-                else
-                    do! gameLaunchSignal.Task
-                    if delay > TimeSpan.Zero then
-                        Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after game launch"
-                        do! Task.Delay(delay)
+                do! gameLaunchSignal.Task
+                if delay > TimeSpan.Zero then
+                    Log.info $"Process %s{proc.Info.Name} will start %.0f{delay.TotalSeconds}s after game launch"
+                    do! Task.Delay(delay)
                 return Process.launchProcesses false [proc.Info]
             }
             delayedTasks.Add(t)

--- a/src/MinEdLauncher/Process.fs
+++ b/src/MinEdLauncher/Process.fs
@@ -29,6 +29,12 @@ let launchProcesses printOutput (processes:LauncherProcess list) =
             Log.exn e $"Unable to start process %s{l.Name}"
             None)
 
+let launchProcessesDelayed (delay: TimeSpan) (processes: LauncherProcess list) = task {
+    if delay > TimeSpan.Zero then
+        do! Threading.Tasks.Task.Delay(delay)
+    return launchProcesses false processes
+}
+
 let stopProcesses (timeout: TimeSpan) (processes: (Process * LauncherProcess) list) =
     processes
     |> List.iter (fun (p, l) ->

--- a/src/MinEdLauncher/Settings.fs
+++ b/src/MinEdLauncher/Settings.fs
@@ -362,7 +362,10 @@ let parseDelayReference (value: string option) =
     match value |> Option.map (fun s -> s.ToLowerInvariant()) with
     | None | Some "processstart" -> ProcessStart
     | Some "gamelaunch" -> GameLaunch
-    | Some "gamerunning" -> GameRunning
+    | Some "journalactive" -> JournalActive
+    | Some "gamerunning" ->
+        Log.warn "delayReference 'gameRunning' is deprecated; use 'journalActive' instead"
+        JournalActive
     | Some unknown ->
         Log.warn $"Unknown delay reference '%s{unknown}', defaulting to processStart"
         ProcessStart

--- a/src/MinEdLauncher/Settings.fs
+++ b/src/MinEdLauncher/Settings.fs
@@ -35,7 +35,8 @@ let defaults =
       ShutdownTimeout = TimeSpan.FromSeconds(10)
       CacheDir = ""
       GameStartDelay = TimeSpan.Zero
-      ShutdownDelay = TimeSpan.Zero }
+      ShutdownDelay = TimeSpan.Zero
+      JournalDir = None }
     
 [<RequireQualifiedAccess>]
 type FrontierCredResult = Found of string * string * string option | NotFound of string | UnexpectedFormat of string | Error of string
@@ -218,7 +219,8 @@ type Config =
       [<DefaultValue("0")>]
       GameStartDelay: int
       [<DefaultValue("0")>]
-      ShutdownDelay: int }
+      ShutdownDelay: int
+      JournalDir: string option }
 let private levenshteinDistance (a: string) (b: string) =
     let a = a.ToLowerInvariant()
     let b = b.ToLowerInvariant()
@@ -236,7 +238,7 @@ let private knownConfigKeys =
     [ "apiUri"; "watchForCrashes"; "gameLocation"; "language"; "autoUpdate"
       "checkForLauncherUpdates"; "maxConcurrentDownloads"; "forceUpdate"
       "processes"; "shutdownProcesses"; "filterOverrides"; "additionalProducts"
-      "shutdownTimeout"; "cacheDir"; "gameStartDelay"; "shutdownDelay" ]
+      "shutdownTimeout"; "cacheDir"; "gameStartDelay"; "shutdownDelay"; "journalDir" ]
     |> OrdinalIgnoreCaseSet.ofSeq
 
 let private warnUnknownKeys (configRoot: IConfigurationRoot) =
@@ -395,7 +397,7 @@ let getSettings args appDir fileConfig = task {
             | None -> Error "Failed to find Elite Dangerous install directory"
             | Some dir -> Ok dir
     let apiUri = Uri(fileConfig.ApiUri)
-    let processes = fileConfig.Processes |> List.map (fun p -> {| Info = mapProcessConfig p; RestartOnRelaunch = p.RestartOnRelaunch; KeepOpen = p.KeepOpen; Delay = { Seconds = p.Delay; Reference = parseDelayReference p.DelayReference } |})
+    let processes = fileConfig.Processes |> List.map (fun p -> {| Info = mapProcessConfig p; RestartOnRelaunch = p.RestartOnRelaunch; KeepOpen = p.KeepOpen; Delay = { Amount = TimeSpan.FromSeconds(p.Delay); Reference = parseDelayReference p.DelayReference } |})
     let shutdownProcesses = fileConfig.ShutdownProcesses |> List.map mapProcessConfig
     let filterOverrides = fileConfig.FilterOverrides |> Seq.map (fun o -> o.Sku, o.Filter) |> OrdinalIgnoreCaseMap.ofSeq
     let fallbackDirs platform =
@@ -427,6 +429,7 @@ let getSettings args appDir fileConfig = task {
                                                           ShutdownTimeout = TimeSpan.FromSeconds(fileConfig.ShutdownTimeout)
                                                           CacheDir = fileConfig.CacheDir |> Option.defaultValue Environment.cacheDir
                                                           GameStartDelay = TimeSpan.FromSeconds(fileConfig.GameStartDelay)
-                                                          ShutdownDelay = TimeSpan.FromSeconds(fileConfig.ShutdownDelay) 
+                                                          ShutdownDelay = TimeSpan.FromSeconds(fileConfig.ShutdownDelay)
+                                                          JournalDir = fileConfig.JournalDir
                                            })
 }

--- a/src/MinEdLauncher/Settings.fs
+++ b/src/MinEdLauncher/Settings.fs
@@ -191,7 +191,9 @@ type ProcessConfig =
     { FileName: string
       Arguments: string option
       RestartOnRelaunch: bool
-      KeepOpen: bool }
+      KeepOpen: bool
+      Delay: int
+      DelayReference: string option }
 [<CLIMutable>]
 type Config =
     { [<DefaultValue("https://api.zaonce.net")>]
@@ -319,10 +321,12 @@ let private parseConfigFromRoot (configRoot: IConfigurationRoot) =
                 let args = section.GetValue<string>("arguments")
                 let restart = section.GetValue<bool>("restartOnRelaunch")
                 let keepOpen = section.GetValue<bool>("keepOpen")
+                let delay = section.GetValue<int>("delay")
+                let delayReference = section.GetValue<string>("delayReference") |> Option.ofObj
                 if String.IsNullOrWhiteSpace(fileName) then
                     None
                 else
-                    Some { FileName = fileName; Arguments = Option.ofObj args; RestartOnRelaunch = restart; KeepOpen = keepOpen })
+                    Some { FileName = fileName; Arguments = Option.ofObj args; RestartOnRelaunch = restart; KeepOpen = keepOpen; Delay = delay; DelayReference = delayReference })
             |> Seq.toList
     let parseAdditionalProducts() =
         configRoot.GetSection("additionalProducts").GetChildren()
@@ -352,6 +356,15 @@ let parseConfig (baseFile: string) (overlayFile: string option) =
             ConfigurationBuilder().AddJsonStream(mergedStream).Build()
     parseConfigFromRoot configRoot
    
+let parseDelayReference (value: string option) =
+    match value |> Option.map (fun s -> s.ToLowerInvariant()) with
+    | None | Some "processstart" -> ProcessStart
+    | Some "gamelaunch" -> GameLaunch
+    | Some "gamerunning" -> GameRunning
+    | Some unknown ->
+        Log.warn $"Unknown delay reference '%s{unknown}', defaulting to processStart"
+        ProcessStart
+
 let private mapProcessConfig p =
     let pInfo = ProcessStartInfo()
     pInfo.FileName <- p.FileName
@@ -382,7 +395,7 @@ let getSettings args appDir fileConfig = task {
             | None -> Error "Failed to find Elite Dangerous install directory"
             | Some dir -> Ok dir
     let apiUri = Uri(fileConfig.ApiUri)
-    let processes = fileConfig.Processes |> List.map (fun p -> {| Info = mapProcessConfig p; RestartOnRelaunch = p.RestartOnRelaunch; KeepOpen = p.KeepOpen |}) 
+    let processes = fileConfig.Processes |> List.map (fun p -> {| Info = mapProcessConfig p; RestartOnRelaunch = p.RestartOnRelaunch; KeepOpen = p.KeepOpen; Delay = { Seconds = p.Delay; Reference = parseDelayReference p.DelayReference } |})
     let shutdownProcesses = fileConfig.ShutdownProcesses |> List.map mapProcessConfig
     let filterOverrides = fileConfig.FilterOverrides |> Seq.map (fun o -> o.Sku, o.Filter) |> OrdinalIgnoreCaseMap.ofSeq
     let fallbackDirs platform =

--- a/src/MinEdLauncher/Types.fs
+++ b/src/MinEdLauncher/Types.fs
@@ -108,6 +108,10 @@ type AuthorizedProduct =
       SortKey: int
       Sku: string
       TestApi: bool }
+type DelayReference = ProcessStart | GameLaunch | GameRunning
+type ProcessDelay = { Seconds: int; Reference: DelayReference }
+    with static member Default = { Seconds = 0; Reference = ProcessStart }
+
 type LauncherProcess = Host of ProcessStartInfo | Flatpak of appId: string * startInfo: ProcessStartInfo with
     member this.Name = match this with Host startInfo -> startInfo.FileName | Flatpak (appId, _) -> appId
     member this.StartInfo = match this with Host startInfo -> startInfo | Flatpak (_, startInfo) -> startInfo
@@ -133,7 +137,7 @@ type LauncherSettings =
       CheckForLauncherUpdates: bool
       MaxConcurrentDownloads: int
       ForceUpdate: string Set
-      Processes: {| Info: LauncherProcess; RestartOnRelaunch: bool; KeepOpen: bool |} list
+      Processes: {| Info: LauncherProcess; RestartOnRelaunch: bool; KeepOpen: bool; Delay: ProcessDelay |} list
       ShutdownProcesses: LauncherProcess list
       FilterOverrides: OrdinalIgnoreCaseMap<string>
       AdditionalProducts: AuthorizedProduct list

--- a/src/MinEdLauncher/Types.fs
+++ b/src/MinEdLauncher/Types.fs
@@ -109,8 +109,8 @@ type AuthorizedProduct =
       Sku: string
       TestApi: bool }
 type DelayReference = ProcessStart | GameLaunch | GameRunning
-type ProcessDelay = { Seconds: int; Reference: DelayReference }
-    with static member Default = { Seconds = 0; Reference = ProcessStart }
+type ProcessDelay = { Amount: TimeSpan; Reference: DelayReference }
+    with static member Default = { Amount = TimeSpan.Zero; Reference = ProcessStart }
 
 type LauncherProcess = Host of ProcessStartInfo | Flatpak of appId: string * startInfo: ProcessStartInfo with
     member this.Name = match this with Host startInfo -> startInfo.FileName | Flatpak (appId, _) -> appId
@@ -145,7 +145,8 @@ type LauncherSettings =
       ShutdownTimeout: TimeSpan
       CacheDir: string
       GameStartDelay: TimeSpan
-      ShutdownDelay: TimeSpan }
+      ShutdownDelay: TimeSpan
+      JournalDir: string option }
 type ProductMode = Online | Offline
 type VersionInfo =
     { Name: string

--- a/src/MinEdLauncher/Types.fs
+++ b/src/MinEdLauncher/Types.fs
@@ -108,7 +108,7 @@ type AuthorizedProduct =
       SortKey: int
       Sku: string
       TestApi: bool }
-type DelayReference = ProcessStart | GameLaunch | GameRunning
+type DelayReference = ProcessStart | GameLaunch | JournalActive
 type ProcessDelay = { Amount: TimeSpan; Reference: DelayReference }
     with static member Default = { Amount = TimeSpan.Zero; Reference = ProcessStart }
 

--- a/tests/Settings.fs
+++ b/tests/Settings.fs
@@ -380,6 +380,83 @@ let tests =
                 // /* args are considered whitelist args and not unknown
                 let args = args |> Array.filter (fun arg -> arg = null || (arg.StartsWith('/') && arg.Length < 2))
                 let settings = parse args
-                
+
                 settings = Settings.defaults
+    ]
+
+[<Tests>]
+let configTests =
+    let parseConfigWithProcesses (processJson: string) =
+        let json = $"""{{
+            "apiUri": "https://api.zaonce.net",
+            "watchForCrashes": false,
+            "processes": [%s{processJson}],
+            "shutdownProcesses": [],
+            "filterOverrides": [],
+            "additionalProducts": []
+        }}"""
+        let path = Path.GetTempFileName()
+        try
+            File.WriteAllText(path, json)
+            match parseConfig path with
+            | Ok config -> config.Processes
+            | Error _ -> failwith "Failed to parse config"
+        finally
+            File.Delete(path)
+
+    testList "Parsing process delay config" [
+        test "No delay fields defaults to 0 seconds and processStart" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test" }"""
+            Expect.hasLength procs 1 ""
+            Expect.equal procs.[0].Delay 0 ""
+            Expect.equal procs.[0].DelayReference None ""
+        }
+        test "delay only defaults to processStart reference" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": 10 }"""
+            Expect.equal procs.[0].Delay 10 ""
+            Expect.equal procs.[0].DelayReference None ""
+        }
+        test "delay with gameLaunch reference" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": 5, "delayReference": "gameLaunch" }"""
+            Expect.equal procs.[0].Delay 5 ""
+            Expect.equal procs.[0].DelayReference (Some "gameLaunch") ""
+        }
+        test "delay with gameRunning reference" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": 0, "delayReference": "gameRunning" }"""
+            Expect.equal procs.[0].Delay 0 ""
+            Expect.equal procs.[0].DelayReference (Some "gameRunning") ""
+        }
+        test "Negative delay is preserved" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": -5, "delayReference": "gameLaunch" }"""
+            Expect.equal procs.[0].Delay -5 ""
+        }
+    ]
+
+[<Tests>]
+let delayReferenceTests =
+    testList "Parsing delay reference values" [
+        test "None defaults to ProcessStart" {
+            let result = Settings.parseDelayReference None
+            Expect.equal result ProcessStart ""
+        }
+        test "processStart maps to ProcessStart" {
+            let result = Settings.parseDelayReference (Some "processStart")
+            Expect.equal result ProcessStart ""
+        }
+        test "gameLaunch maps to GameLaunch" {
+            let result = Settings.parseDelayReference (Some "gameLaunch")
+            Expect.equal result GameLaunch ""
+        }
+        test "gameRunning maps to GameRunning" {
+            let result = Settings.parseDelayReference (Some "gameRunning")
+            Expect.equal result GameRunning ""
+        }
+        test "Unknown value defaults to ProcessStart" {
+            let result = Settings.parseDelayReference (Some "bogus")
+            Expect.equal result ProcessStart ""
+        }
+        test "Case insensitive matching" {
+            let result = Settings.parseDelayReference (Some "GAMELAUNCH")
+            Expect.equal result GameLaunch ""
+        }
     ]

--- a/tests/Settings.fs
+++ b/tests/Settings.fs
@@ -421,10 +421,10 @@ let configTests =
             Expect.equal procs.[0].Delay 5 ""
             Expect.equal procs.[0].DelayReference (Some "gameLaunch") ""
         }
-        test "delay with gameRunning reference" {
-            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": 0, "delayReference": "gameRunning" }"""
+        test "delay with journalActive reference" {
+            let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": 0, "delayReference": "journalActive" }"""
             Expect.equal procs.[0].Delay 0 ""
-            Expect.equal procs.[0].DelayReference (Some "gameRunning") ""
+            Expect.equal procs.[0].DelayReference (Some "journalActive") ""
         }
         test "Negative delay is preserved" {
             let procs = parseConfigWithProcesses """{ "fileName": "/usr/bin/test", "delay": -5, "delayReference": "gameLaunch" }"""
@@ -447,9 +447,13 @@ let delayReferenceTests =
             let result = Settings.parseDelayReference (Some "gameLaunch")
             Expect.equal result GameLaunch ""
         }
-        test "gameRunning maps to GameRunning" {
+        test "journalActive maps to JournalActive" {
+            let result = Settings.parseDelayReference (Some "journalActive")
+            Expect.equal result JournalActive ""
+        }
+        test "gameRunning is accepted as deprecated alias for JournalActive" {
             let result = Settings.parseDelayReference (Some "gameRunning")
-            Expect.equal result GameRunning ""
+            Expect.equal result JournalActive ""
         }
         test "Unknown value defaults to ProcessStart" {
             let result = Settings.parseDelayReference (Some "bogus")

--- a/tests/Settings.fs
+++ b/tests/Settings.fs
@@ -386,7 +386,7 @@ let tests =
 
 [<Tests>]
 let configTests =
-    let parseConfigWithProcesses (processJson: string) =
+    let parseConfigWithProcesses (processJson: string) : ProcessConfig list =
         let json = $"""{{
             "apiUri": "https://api.zaonce.net",
             "watchForCrashes": false,
@@ -398,7 +398,7 @@ let configTests =
         let path = Path.GetTempFileName()
         try
             File.WriteAllText(path, json)
-            match parseConfig path with
+            match parseConfig path None with
             | Ok config -> config.Processes
             | Error _ -> failwith "Failed to parse config"
         finally


### PR DESCRIPTION
Add `delay` (int, seconds) and `delayReference` (string) fields to process config. Three reference points:

- `processStart` (default) — relative to when processes normally launch, before `gameStartDelay` and before the game binary. With `delay: 0` this is identical to current behavior.
- `gameLaunch` — relative to when the game binary actually launches (after `gameStartDelay`). Supports negative values to start processes N seconds before game launch.
- `gameRunning` — triggers once on first journal file activity, i.e. when the game is actually up and writing logs. Only fires once per session (not on every journal write).

Journal directory auto-discovered across Windows, native Linux, and Proton paths.

### Example config

```json
{
  "processes": [
    { "fileName": "/usr/bin/edmc", "delay": 30, "delayReference": "gameLaunch" },
    { "fileName": "/usr/bin/afk-monitor", "delayReference": "gameRunning" },
    { "fileName": "/usr/bin/obs", "arguments": "--startrecording", "delay": -5, "delayReference": "gameLaunch" }
  ]
}
```

Fixes #187 — EDMC and similar tools that need the game to be loaded before they start can now use `"delayReference": "gameRunning"` to wait for journal activity.

Also fixes pre-existing `FakeTimeProvider` test failure in Legendary.fs.