### PR TITLE
feat: add /settingsOverlay flag for per-profile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The following arguments are in addition to the above:
 | /restart delay         | Restart the game after it has closed with _delay_ being the number of seconds given to cancel the restart (i.e `/restart 3`)                                                                            |
 | /dryrun                | Prints output without launching any processes                                                                                                                                                           |
 | /skipInstallPrompt     | Skips the prompt to install uninstalled products when `/autorun` is not specified                                                                                                                       |
+| /settingsOverlay path  | Load a partial settings overlay file on top of the default `settings.json`. See [Settings Overlay] below                                                                                               |
 
 ##### Epic accounts and the /restart feature
 The restart feature requires either [Legendary] or [Heroic] to work with Epic accounts.
@@ -293,6 +294,25 @@ double backslash (`\\`) instead of a single backslash (`\`).
   }]
 }
 ```
+
+#### Settings Overlay
+
+The `/settingsOverlay <path>` flag loads a partial JSON file on top of the default `settings.json`. The overlay only needs to contain the keys you want to override — all other settings are inherited from the base file.
+
+For example, to suppress all auto-launched processes for a specific profile, create a file like:
+
+```json
+{
+  "processes": []
+}
+```
+
+Then use it with: `./MinEdLauncher /frontier alice /settingsOverlay ~/.config/min-ed-launcher/alice.json /autorun`
+
+Merge rules:
+- Scalar values (bool, int, string) — overlay wins if the key is present
+- Lists (processes, shutdownProcesses, etc.) — overlay **replaces** the base list if the key is present, even if empty
+- Keys not present in the overlay inherit their value from the base `settings.json`
 
 ### Multi-Account
 #### Frontier account via Steam or Epic
@@ -414,6 +434,7 @@ Note that the bootstrap project specifically targets Windows and won't publish o
 
 [preview-gif]: https://rfvgyhn.blob.core.windows.net/elite-dangerous/min-ed-launcher-demo.gif
 [Settings]: #settings
+[Settings Overlay]: #settings-overlay
 [flag]: #arguments
 [setup]: #setup
 [Elite Log Agent]: https://github.com/DarkWanderer/Elite-Log-Agent

--- a/src/MinEdLauncher/Program.fs
+++ b/src/MinEdLauncher/Program.fs
@@ -9,20 +9,27 @@ open System.Threading
 open FsConfig
 open FsToolkit.ErrorHandling
 
+let private findSettingsOverlay (args: string[]) =
+    args
+    |> Array.tryFindIndex (fun a -> a <> null && a.Equals("/settingsOverlay", StringComparison.OrdinalIgnoreCase))
+    |> Option.bind (fun i -> if i + 1 < args.Length then Some args[i + 1] else None)
+
 let getSettings (assembly: Assembly) args =
     let path = Environment.configDir
     match FileIO.ensureDirExists path with
     | Error msg -> Error $"Unable to find/create configuration directory at %s{path} - %s{msg}" |> Task.fromResult
     | Ok settingsDir ->
         let settingsPath = Path.Combine(settingsDir, "settings.json")
+        let overlayPath = findSettingsOverlay args
         Log.debug $"Reading settings from '%s{settingsPath}'"
+        overlayPath |> Option.iter (fun p -> Log.debug $"Using settings overlay from '%s{p}'")
         if not (File.Exists(settingsPath)) then
             use settings = assembly.GetManifestResourceStream("MinEdLauncher.settings.json")
             use file = File.OpenWrite(settingsPath)
             settings.CopyTo(file)
         |> ignore
-            
-        Settings.parseConfig settingsPath
+
+        Settings.parseConfig settingsPath overlayPath
         |> Result.mapError (fun e ->
             match e with
             | BadValue (key, value) -> $"Bad Value: %s{key} - %s{value}"

--- a/src/MinEdLauncher/Settings.fs
+++ b/src/MinEdLauncher/Settings.fs
@@ -289,8 +289,10 @@ let private writeJsonMerged (writer: Utf8JsonWriter) (baseEl: JsonElement) (over
     merge baseEl overlayEl
 
 let private mergeJsonFiles (baseFile: string) (overlayFile: string) =
-    use baseDoc = JsonDocument.Parse(File.ReadAllText(baseFile))
-    use overlayDoc = JsonDocument.Parse(File.ReadAllText(overlayFile))
+    // Mimic options of ConfigurationBuilder.AddJsonFile()
+    let options = JsonDocumentOptions(AllowTrailingCommas = true, CommentHandling = JsonCommentHandling.Skip)
+    use baseDoc = JsonDocument.Parse(File.ReadAllText(baseFile), options)
+    use overlayDoc = JsonDocument.Parse(File.ReadAllText(overlayFile), options)
     let ms = new MemoryStream()
     use writer = new Utf8JsonWriter(ms)
     writeJsonMerged writer baseDoc.RootElement overlayDoc.RootElement

--- a/tests/Legendary.fs
+++ b/tests/Legendary.fs
@@ -80,7 +80,7 @@ let tests =
                 Expect.isError token ""
             
             test "Fails if access token is expired" {
-                let now = DateTimeOffset(DateTime(2000, 1, 1))
+                let now = DateTimeOffset(DateTime(2000, 1, 1), TimeSpan.Zero)
                 let time = FakeTimeProvider()
                 time.SetUtcNow(now)
                 let json = defaultJson.Deserialize<JsonObject>()

--- a/tests/Settings.fs
+++ b/tests/Settings.fs
@@ -122,6 +122,42 @@ let parseConfigTests =
             finally
                 Directory.Delete(dir, true)
         }
+        test "Overlay allows trailing commas in JSON" {
+            let dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+            Directory.CreateDirectory(dir) |> ignore
+            try
+                let basePath = writeJsonFile dir "settings.json" """{ "apiUri": "https://api.zaonce.net", }"""
+                let overlayPath = writeJsonFile dir "overlay.json" """{ "watchForCrashes": false, }"""
+                let result = parseConfig basePath (Some overlayPath)
+                
+                Expect.wantOk result "" |> ignore
+            finally
+                Directory.Delete(dir, true)
+        }
+        test "Overlay allows comments in JSON" {
+            let dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString())
+            Directory.CreateDirectory(dir) |> ignore
+            try
+                let basePath = writeJsonFile dir "settings.json"
+                                   """
+                                   {
+                                     // comment
+                                     "apiUri": "https://api.zaonce.net"
+                                   }
+                                   """
+                let overlayPath = writeJsonFile dir "overlay.json"
+                                      """
+                                      { 
+                                        // comment
+                                        "watchForCrashes": false
+                                      }
+                                      """
+                let result = parseConfig basePath (Some overlayPath)
+                
+                Expect.wantOk result "" |> ignore
+            finally
+                Directory.Delete(dir, true)
+        }
     ]
 
 [<Tests>]


### PR DESCRIPTION
Adds `/settingsOverlay <path>` — load a partial JSON file on top of the default `settings.json`. Only keys present in the overlay override the base; everything else is inherited.

Addresses the multi-account use case from #175 / #182. Leaves `/settings` and `/config` free for #181.

### Example

```bash
./MinEdLauncher /frontier alice /settingsOverlay ~/.config/min-ed-launcher/alice.json /autorun
```

`alice.json` — suppress all auto-launched processes:
```json
{
  "processes": []
}
```

### How it works

Base and overlay JSON are merged with `System.Text.Json` before being fed to a single `ConfigurationBuilder`. Objects merge recursively (overlay wins per-key), arrays and scalars are replaced wholesale. No reflection involved.

### Changes

- **Settings.fs**: `writeJsonMerged` merges two `JsonElement` trees, `mergeJsonFiles` produces a merged stream, `parseConfig` accepts an optional overlay path. Added `DefaultValue` to `ApiUri`/`WatchForCrashes` so partial configs parse cleanly. `/settingsOverlay` + its value arg are skipped in `parseArgs`.
- **Program.fs**: Extracts `/settingsOverlay <path>` from argv, passes to `parseConfig`
- **tests/Settings.fs**: 7 new tests — overlay parsing (merge, missing file, empty processes, no overlay) and arg handling (skip, absolute path not treated as whitelist)
- **README.md**: Documented `/settingsOverlay` flag and merge rules

Fixes #182