### PR TITLE
Look in the working directory for Elite

### DIFF
--- a/src/MinEdLauncher/Settings.fs
+++ b/src/MinEdLauncher/Settings.fs
@@ -386,7 +386,7 @@ let private mapProcessConfig p =
         Host pInfo
 let getSettings args appDir fileConfig = task {
     let findCbLaunchDir paths =
-        appDir :: paths
+        Directory.GetCurrentDirectory() :: appDir :: paths
         |> List.map Some
         |> List.append [ fileConfig.GameLocation ]
         |> List.choose id


### PR DESCRIPTION
This is so that you can set the "Current" / Working Directory without having to move MinEdLauncher.  
Very handy on when min-ed-launcher cannot find the Elite Directory.

I use this with lutris so that I can start Elite via MinEdLauncher without moving it to the same directory.